### PR TITLE
Logger delegate utility

### DIFF
--- a/logging/src/main/java/com/rarible/core/logging/Logger.kt
+++ b/logging/src/main/java/com/rarible/core/logging/Logger.kt
@@ -1,0 +1,18 @@
+package com.rarible.core.logging
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+import kotlin.reflect.full.companionObject
+
+class Logger<in R : Any> : ReadOnlyProperty<R, Logger> {
+    override fun getValue(thisRef: R, property: KProperty<*>): Logger
+        = LoggerFactory.getLogger(getClassForLogging(thisRef.javaClass))
+
+    private fun <T : Any> getClassForLogging(javaClass: Class<T>): Class<*> {
+        return javaClass.enclosingClass?.takeIf {
+            it.kotlin.companionObject?.java == javaClass
+        } ?: javaClass
+    }
+}

--- a/logging/src/test/java/com/rarible/core/logging/LoggerTest.kt
+++ b/logging/src/test/java/com/rarible/core/logging/LoggerTest.kt
@@ -1,0 +1,16 @@
+package com.rarible.core.logging
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+
+internal class LoggerTest {
+
+    @Test
+    fun `should pick correct logger instance`() {
+        Assertions.assertThat(logger.name).isEqualTo(this::class.qualifiedName)
+    }
+
+    companion object {
+        val logger by Logger()
+    }
+}


### PR DESCRIPTION
Makes instantiation of loggers easier in code. E.g.

```kotlin
class Business {

    fun earnAMillion() {
        logger.info("Started earning a million")
    }

    companion object {
        val logger by Logger()
    }
}
```