### PR TITLE
fix(PT-5585): bump the library version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     </distributionManagement>
 
     <properties>
-        <revision>2.7.17</revision>
+        <revision>2.7.18</revision>
         <logback.version>1.2.11</logback.version>
         <logstash-encoder.version>7.0.1</logstash-encoder.version>
         <testcontainers.version>1.16.2</testcontainers.version>


### PR DESCRIPTION
Missed to update the version in the previous kafka logging change.